### PR TITLE
[16.0][IMP] spreadsheet_dashboard_oca: Dashboard editability

### DIFF
--- a/spreadsheet_dashboard_oca/__manifest__.py
+++ b/spreadsheet_dashboard_oca/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     "data": [
         "wizards/spreadsheet_spreadsheet_import.xml",
+        "views/spreadsheet_dashboard_group_views.xml",
         "views/spreadsheet_dashboard.xml",
         "data/spreadsheet_spreadsheet_import_mode.xml",
     ],

--- a/spreadsheet_dashboard_oca/static/description/index.html
+++ b/spreadsheet_dashboard_oca/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/spreadsheet_dashboard_oca/views/spreadsheet_dashboard.xml
+++ b/spreadsheet_dashboard_oca/views/spreadsheet_dashboard.xml
@@ -15,13 +15,25 @@
         <field name="arch" type="xml">
             <tree position="attributes">
                 <attribute name="create">1</attribute>
+                <attribute name="decoration-muted">not active</attribute>
             </tree>
             <tree position="inside">
+                <field name="can_edit" invisible="1" />
                 <field
                     name="data"
                     groups="base.group_no_one"
                     widget="binary"
                     filename="name"
+                />
+                <!-- Put the button 2 times for having the edit button explicitly disabled for discoverability -->
+                <button
+                    name="open_spreadsheet"
+                    type="object"
+                    string="Edit"
+                    icon="fa-pencil"
+                    disabled="1"
+                    groups="base.group_system"
+                    attrs="{'invisible': [('can_edit', '=', True)]}"
                 />
                 <button
                     name="open_spreadsheet"
@@ -29,7 +41,16 @@
                     string="Edit"
                     icon="fa-pencil"
                     groups="base.group_system"
+                    attrs="{'invisible': [('can_edit', '=', False)]}"
                 />
+                <button
+                    name="copy"
+                    type="object"
+                    string="Copy"
+                    icon="fa-copy"
+                    groups="base.group_system"
+                />
+                <field name="active" widget="boolean_toggle" />
             </tree>
         </field>
     </record>

--- a/spreadsheet_dashboard_oca/views/spreadsheet_dashboard_group_views.xml
+++ b/spreadsheet_dashboard_oca/views/spreadsheet_dashboard_group_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record
+        model="ir.actions.act_window"
+        id="spreadsheet_dashboard.spreadsheet_dashboard_action_configuration_dashboards"
+    >
+        <field name="context">{'active_test': False}</field>
+    </record>
+</odoo>


### PR DESCRIPTION
All the spreadsheet dashboards coming from Odoo in the modules spreadsheet_dashboard* are noupdate="0", which means that if you modify anything via this module, and then you update the module, all the changes will be lost.

To avoid frustrations and to allow seamless updates, the following mechanisms have been put in place:

- Spreadsheet dashboards now have an active field.
- Only the manually created dashboards or those coming from data with noupdate="1" will be editable.
- There's a mechanism for copying existing dashboards.

So, for modifying one of the standard dashboards, the steps will be:

- Duplicate it through the "Copy" button.
- Disable the standard one.
- Edit the copy.

![imagen](https://github.com/OCA/spreadsheet/assets/7165771/a14a70a9-ddd1-4040-b171-270709679957)

@Tecnativa TT49379