### PR TITLE
[FIX] spreadsheet_oca: Error when deleting a worksheet

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet.xml
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet.xml
@@ -282,7 +282,13 @@
             onClosed.bind="closeDialog"
             t-if="state.dialogDisplayed"
         >
-            <input type="text" class="form-control" t-model="state.dialogContent" />
+            <span t-if="state.dialogHideInputBox" t-esc="state.dialogContent" />
+            <input
+                t-else=""
+                type="text"
+                class="form-control"
+                t-model="state.dialogContent"
+            />
             <t t-set-slot="buttons">
                 <button
                     class="btn btn-primary"

--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_renderer.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_renderer.esm.js
@@ -87,6 +87,7 @@ export class SpreadsheetRenderer extends Component {
         useSubEnv({
             saveSpreadsheet: this.onSpreadsheetSaved.bind(this),
             editText: this.editText.bind(this),
+            askConfirmation: this.askConfirmation.bind(this),
         });
         onWillStart(async () => {
             await loadSpreadsheetDependencies();
@@ -105,6 +106,7 @@ export class SpreadsheetRenderer extends Component {
         this.state.dialogDisplayed = false;
         this.state.dialogTitle = "Spreadsheet";
         this.state.dialogContent = undefined;
+        this.state.dialogHideInputBox = false;
     }
     onSpreadsheetSaved() {
         const data = this.spreadsheet_model.exportData();
@@ -117,6 +119,15 @@ export class SpreadsheetRenderer extends Component {
         this.state.dialogDisplayed = true;
         this.confirmDialog = () => {
             callback(this.state.dialogContent);
+            this.closeDialog();
+        };
+    }
+    askConfirmation(content, confirm) {
+        this.state.dialogContent = content;
+        this.state.dialogDisplayed = true;
+        this.state.dialogHideInputBox = true;
+        this.confirmDialog = () => {
+            confirm();
             this.closeDialog();
         };
     }


### PR DESCRIPTION
Closes https://github.com/OCA/spreadsheet/issues/32

- Fixed issue where askConfirmation missing in Odoo Community causing crash when deleting a worksheet
- Added new property to state "dialogHideInputBox" which allows use of the existing dialog GUI as a readonly message box for alerts, or an inputbox taking user input