### PR TITLE
[16.0][FIX] spreadsheet_oca: Keep pivot order

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
@@ -184,6 +184,7 @@ export class ActionSpreadsheetOca extends Component {
                 rowGroupBys,
                 activeMeasures: this.import_data.metaData.activeMeasures,
                 resModel: this.import_data.metaData.resModel,
+                sortedColumn: this.import_data.metaData.sortedColumn,
             },
             searchParams: this.import_data.searchParams,
         };


### PR DESCRIPTION
When adding a pivot table to a spreadsheet, it does not maintain the specified order because the sortedColumn option is not being completed.

Steps to reproduce the issue:

1. Go to a pivot table
2. Change the default order
3. Add to the spreadsheet

The added table will not have preserved the order.

cc @Tecnativa TT49835

ping @carolinafernandez-tecnativa @pedrobaeza 