### PR TITLE
[16.0][FIX] spreadsheet_oca: Avoid to show dynamic cols when no cols selected

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
@@ -134,6 +134,11 @@ export class PivotPanelDisplay extends Component {
                     {
                         title: this.env._t("Select the quantity of rows"),
                         resModel: "spreadsheet.select.row.number",
+                        context: {
+                            default_can_have_dynamic_cols: Boolean(
+                                cols[0][0].fields.length
+                            ),
+                        },
                         onRecordSaved: async (record) => {
                             resolve({
                                 dynamic_rows: record.data.dynamic_rows,

--- a/spreadsheet_oca/static/src/spreadsheet/pivot_controller.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/pivot_controller.esm.js
@@ -25,6 +25,14 @@ patch(
             );
             return Boolean(colGroupBys.intersection(rowGroupBys).size);
         },
+        containsColGroupBys() {
+            const colGroupBys = new Set(
+                this.model.metaData.colGroupBys
+                    .concat(this.model.metaData.expandedColGroupBys)
+                    .map((el) => el.split(":")[0])
+            );
+            return Boolean(colGroupBys.size);
+        },
         disableSpreadsheetInsertion() {
             return (
                 !this.model.hasData() ||
@@ -50,6 +58,7 @@ patch(
                         default_name: this.model.metaData.title,
                         default_datasource_name: this.model.metaData.title,
                         default_can_be_dynamic: true,
+                        default_can_have_dynamic_cols: this.containsColGroupBys(),
                         default_import_data: {
                             mode: "pivot",
                             metaData: JSON.parse(JSON.stringify(this.model.metaData)),

--- a/spreadsheet_oca/wizards/spreadsheet_select_row_number.py
+++ b/spreadsheet_oca/wizards/spreadsheet_select_row_number.py
@@ -10,5 +10,6 @@ class SpreadsheetSelectRowNumber(models.TransientModel):
 
     dynamic_rows = fields.Boolean()
     number_of_rows = fields.Integer()
+    can_have_dynamic_cols = fields.Boolean()
     dynamic_cols = fields.Boolean()
     number_of_cols = fields.Integer()

--- a/spreadsheet_oca/wizards/spreadsheet_select_row_number.xml
+++ b/spreadsheet_oca/wizards/spreadsheet_select_row_number.xml
@@ -13,7 +13,11 @@
                             name="number_of_rows"
                             attrs="{'invisible': [('dynamic_rows', '=', False)]}"
                         />
-                        <field name="dynamic_cols" />
+                        <field name="can_have_dynamic_cols" invisible="1" />
+                        <field
+                            name="dynamic_cols"
+                            attrs="{'invisible': [('can_have_dynamic_cols', '=', False)]}"
+                        />
                         <field
                             name="number_of_cols"
                             attrs="{'invisible': [('dynamic_cols', '=', False)]}"

--- a/spreadsheet_oca/wizards/spreadsheet_spreadsheet_import.py
+++ b/spreadsheet_oca/wizards/spreadsheet_spreadsheet_import.py
@@ -24,6 +24,7 @@ class SpreadsheetSpreadsheetImport(models.TransientModel):
     import_data = fields.Serialized()
     spreadsheet_id = fields.Many2one("spreadsheet.spreadsheet")
     can_be_dynamic = fields.Boolean()
+    can_have_dynamic_cols = fields.Boolean()
     is_tree = fields.Boolean()
     dynamic = fields.Boolean(
         "Dynamic Rows",

--- a/spreadsheet_oca/wizards/spreadsheet_spreadsheet_import.xml
+++ b/spreadsheet_oca/wizards/spreadsheet_spreadsheet_import.xml
@@ -27,6 +27,7 @@
                             options="{'no_create': True}"
                         />
                         <field name="can_be_dynamic" invisible="1" />
+                        <field name="can_have_dynamic_cols" invisible="1" />
                         <field name="is_tree" invisible="1" />
                         <field
                             name="dynamic"
@@ -40,7 +41,7 @@
                         <field
                             name="dynamic_cols"
                             force_save="1"
-                            attrs="{'invisible': ['|', ('can_be_dynamic', '=', False), ('is_tree', '=', True)]}"
+                            attrs="{'invisible': ['|', ('can_have_dynamic_cols', '=', False), ('is_tree', '=', True)]}"
                         />
                         <field
                             name="number_of_cols"


### PR DESCRIPTION
Steps to reproduce the error:

1. Go to a pivot
2. Remove all groups of columns to set only the measure
3. Add the pivot to a spreadsheet with dynamic columns and a number of columns

An error will be thrown

cc @Tecnativa TT50912 

ping @pedrobaeza @chienandalu 