### PR TITLE
[16.0][FIX] spreadsheet_oca: Clean searchParams of problematic context keys

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
@@ -52,7 +52,25 @@ export class ActionSpreadsheetOca extends Component {
             this.router.pushState({spreadsheet_id: this.spreadsheetId});
         }
     }
-
+    /**
+     * Clean SearchParams of conflictive keys.
+     *
+     * 1. Removed from context pivot conflictive keys.
+     * 2. Removed from context graph conflictive keys.
+     *
+     * @returns {Object}       Formated searchParams.
+     */
+    cleanSearchParams() {
+        const searchParams = this.import_data.searchParams;
+        const context = {};
+        for (var key of Object.keys(searchParams.context)) {
+            if (key.startsWith("pivot_") || key.startsWith("graph_")) {
+                continue;
+            }
+            context[key] = searchParams.context[key];
+        }
+        return {...searchParams, context};
+    }
     async importDataGraph(spreadsheet_model) {
         var sheetId = spreadsheet_model.getters.getActiveSheetId();
         var y = 0;
@@ -78,7 +96,7 @@ export class ActionSpreadsheetOca extends Component {
             background: "#FFFFFF",
             stacked: this.import_data.metaData.stacked,
             metaData: this.import_data.metaData,
-            searchParams: this.import_data.searchParams,
+            searchParams: this.cleanSearchParams(),
             dataSourceId: dataSourceId,
             legendPosition: "top",
             verticalAxisPosition: "left",
@@ -187,7 +205,7 @@ export class ActionSpreadsheetOca extends Component {
                 resModel: this.import_data.metaData.resModel,
                 sortedColumn: this.import_data.metaData.sortedColumn,
             },
-            searchParams: this.import_data.searchParams,
+            searchParams: this.cleanSearchParams(),
             name: this.import_data.name,
         };
         const dataSource = spreadsheet_model.config.dataSources.add(


### PR DESCRIPTION
Before these changes, when a table or chart was added with an active user filter, the user's selections were not respected, either in the groupings or in the measures.

Thanks to these changes, we remove the conflicting keys from the context passed through the searchParams, thus respecting the user's selection in the table/chart itself.

Steps to reproduce the problem:

1. Go to a pivot or graph
2. Save a filter
3. Modify the groups or measures
4. Add to a spreadsheet

Current behavior: The table will not be added with the current selection but it will be added with the filters groups and measures.

Expected behavior:  The table will be added with the current selection.

cc @Tecnativa TT50997

ping @pedrobaeza @chienandalu 