### PR TITLE
[16.0][FIX] Crashes downloading XLSX

### DIFF
--- a/spreadsheet_oca/controllers/main.py
+++ b/spreadsheet_oca/controllers/main.py
@@ -10,6 +10,8 @@ from odoo.http import Controller, content_disposition, request, route
 class SpreadsheetDownloadXLSX(Controller):
     @route("/spreadsheet/xlsx", type="http", auth="user", methods=["POST"])
     def download_spreadsheet_xlsx(self, zip_name, files, **kw):
+        if hasattr(files, "read"):
+            files = files.read().decode("utf-8")
         files = json.loads(files)
         file_bytes = BytesIO()
         with ZipFile(file_bytes, "w") as zip_file:


### PR DESCRIPTION
this solves

```
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not FileStorage
```

which happens depending on your werkzeug version when choosing file/download xlsx.

Cherry-pick of https://github.com/OCA/spreadsheet/pull/60/commits/e78586cb93c4fcc31583b6014eb79416eda4a614 minus the js changes