### PR TITLE
[17.0][FIX] spreadsheet_oca: Fix bug where sort order in pivot causes crash

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
@@ -81,8 +81,7 @@ export class PivotPanelDisplay extends Component {
     const sortedColumn = this.props.pivotDefinition.sortedColumn;
     const orderTranslate =
       sortedColumn.order === "asc" ? _t("ascending") : _t("descending");
-    const GroupByDisplayLabel = this.PivotDataSource.getGroupByDisplayLabel(
-      "measure",
+    const GroupByDisplayLabel = this.PivotDataSource.getMeasureDisplayName(
       sortedColumn.measure
     );
     return `${GroupByDisplayLabel} (${orderTranslate})`;


### PR DESCRIPTION
Fix bug where sort order in pivot causes crash due to changed function name getGroupByDisplayLabel to getMeasureDisplayName in V17

![486922582-0ddb1758-5e93-4e09-88e4-ca2dbf9a8865](https://github.com/user-attachments/assets/31d7c854-78eb-44f2-bb02-5807ad11777a)
