### PR TITLE
[17.0][FIX] spreadsheet_oca: The tables overlap when added to an existing spreadsheet

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
@@ -1,20 +1,17 @@
 /** @odoo-module **/
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
-import {
-  makeDynamicCols,
-  makeDynamicRows,
-} from "../utils/dynamic_generators.esm";
-import { ListDataSource } from "@spreadsheet/list/list_data_source";
-import { PivotDataSource } from "@spreadsheet/pivot/pivot_data_source";
-import { SpreadsheetControlPanel } from "./spreadsheet_controlpanel.esm";
-import { SpreadsheetRenderer } from "./spreadsheet_renderer.esm";
-import { registry } from "@web/core/registry";
-import { useService } from "@web/core/utils/hooks";
+import {makeDynamicCols, makeDynamicRows} from "../utils/dynamic_generators.esm";
+import {ListDataSource} from "@spreadsheet/list/list_data_source";
+import {PivotDataSource} from "@spreadsheet/pivot/pivot_data_source";
+import {SpreadsheetControlPanel} from "./spreadsheet_controlpanel.esm";
+import {SpreadsheetRenderer} from "./spreadsheet_renderer.esm";
+import {registry} from "@web/core/registry";
+import {useService} from "@web/core/utils/hooks";
 
 const uuidGenerator = new spreadsheet.helpers.UuidGenerator();
 const actionRegistry = registry.category("actions");
-const { Component, onMounted, onWillStart, useSubEnv } = owl;
+const {Component, onMounted, onWillStart, useSubEnv} = owl;
 
 export class ActionSpreadsheetOca extends Component {
   setup() {
@@ -39,7 +36,7 @@ export class ActionSpreadsheetOca extends Component {
             this.model,
             "get_spreadsheet_data",
             [[this.spreadsheetId]],
-            { context: { bin_size: false } }
+            {context: {bin_size: false}}
           )
         ) || {};
     });
@@ -63,7 +60,7 @@ export class ActionSpreadsheetOca extends Component {
       this.orm.call(this.model, "write", [this.spreadsheetId, data]);
     } else {
       this.spreadsheetId = await this.orm.call(this.model, "create", [data]);
-      this.router.pushState({ spreadsheet_id: this.spreadsheetId });
+      this.router.pushState({spreadsheet_id: this.spreadsheetId});
     }
   }
   /**
@@ -83,7 +80,7 @@ export class ActionSpreadsheetOca extends Component {
       }
       context[key] = searchParams.context[key];
     }
-    return { ...searchParams, context };
+    return {...searchParams, context};
   }
   async importDataGraph(spreadsheet_model) {
     var sheetId = spreadsheet_model.getters.getActiveSheetId();
@@ -147,9 +144,8 @@ export class ActionSpreadsheetOca extends Component {
       while (row >= 0) {
         for (var col = maxcols; col >= 0; col--) {
           if (
-            spreadsheet_model.getters.getCell(sheetId, col, row) !==
-              undefined &&
-            !spreadsheet_model.getters.getCell(sheetId, col, row).isEmpty()
+            spreadsheet_model.getters.getCell({sheetId, col, row}) !== undefined &&
+            spreadsheet_model.getters.getCell({sheetId, col, row}).content
           ) {
             filled = true;
             break;
@@ -162,10 +158,10 @@ export class ActionSpreadsheetOca extends Component {
       }
       row += 1;
     }
-    return { sheetId, row };
+    return {sheetId, row};
   }
   async importDataList(spreadsheet_model) {
-    var { sheetId, row } = this.importCreateOrReuseSheet(spreadsheet_model);
+    var {sheetId, row} = this.importCreateOrReuseSheet(spreadsheet_model);
     const dataSourceId = uuidGenerator.uuidv4();
     var list_info = {
       metaData: {
@@ -206,7 +202,7 @@ export class ActionSpreadsheetOca extends Component {
     });
   }
   async importDataPivot(spreadsheet_model) {
-    var { sheetId, row } = this.importCreateOrReuseSheet(spreadsheet_model);
+    var {sheetId, row} = this.importCreateOrReuseSheet(spreadsheet_model);
     const dataSourceId = uuidGenerator.uuidv4();
     const colGroupBys = this.import_data.metaData.colGroupBys.concat(
       this.import_data.metaData.expandedColGroupBys
@@ -231,7 +227,7 @@ export class ActionSpreadsheetOca extends Component {
       pivot_info
     );
     await dataSource.load();
-    var { cols, rows, measures } = dataSource.getTableStructure().export();
+    var {cols, rows, measures} = dataSource.getTableStructure().export();
     if (this.import_data.dyn_number_of_rows) {
       const indentations = rows.map((r) => r.indent);
       const max_indentation = Math.max(...indentations);


### PR DESCRIPTION
Before these changes, when a table was added to an existing spreadsheet, it was always being added to row 0 of the sheet, since the call to getCell always returned undefined.

![overlap_example](https://github.com/user-attachments/assets/77cb7e62-494d-4f46-b988-e0d455541350)

After making these changes, the call is made correctly and the cell’s content is retrieved. Since the isEmpty function no longer exists, we now check directly whether it contains the content key.

![no_overlap_example](https://github.com/user-attachments/assets/379773a5-ef61-4431-adc3-52f26b5cfd8d)

cc @Tecnativa TT58043

ping @pedrobaeza @alexmorel-tecnativa 