### PR TITLE
[17.0][FIX] spreadsheet_oca: The tables overlap when added to an existing spreadsheet

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_action.esm.js
@@ -147,9 +147,9 @@ export class ActionSpreadsheetOca extends Component {
       while (row >= 0) {
         for (var col = maxcols; col >= 0; col--) {
           if (
-            spreadsheet_model.getters.getCell(sheetId, col, row) !==
+            spreadsheet_model.getters.getCell({ sheetId, col, row }) !==
               undefined &&
-            !spreadsheet_model.getters.getCell(sheetId, col, row).isEmpty()
+            spreadsheet_model.getters.getCell({ sheetId, col, row }).content
           ) {
             filled = true;
             break;


### PR DESCRIPTION
Before these changes, when a table was added to an existing spreadsheet, it was always being added to row 0 of the sheet, since the call to getCell always returned undefined.

<img width="1317" height="873" alt="image" src="https://github.com/user-attachments/assets/48c62090-ed29-4b5a-8972-7c6ff9e36994" />

After making these changes, the call is made correctly and the cell’s content is retrieved. Since the isEmpty function no longer exists, we now check directly whether it contains the content key.

<img width="1317" height="873" alt="image" src="https://github.com/user-attachments/assets/68e479dc-129c-4f8f-aa43-d2688fbe5180" />

cc @Tecnativa TT58043

ping @pedrobaeza @alexmorel-tecnativa @carlos-lopez-tecnativa 