### PR TITLE
[18.0][IMP] spreadsheet_oca: Change hotkey to add spreadsheet

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/graph_controller.xml
+++ b/spreadsheet_oca/static/src/spreadsheet/graph_controller.xml
@@ -12,7 +12,7 @@
                 data-tooltip="Add to spreadsheet"
                 aria-label="Add to spreadsheet"
                 t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"
-                data-hotkey="s"
+                data-hotkey="t"
             />
         </xpath>
     </t>

--- a/spreadsheet_oca/static/src/spreadsheet/list_controller.xml
+++ b/spreadsheet_oca/static/src/spreadsheet/list_controller.xml
@@ -13,7 +13,7 @@
                     data-tooltip="Add to spreadsheet"
                     aria-label="Add to spreadesheet"
                     t-on-click="(ev) => this.onSpreadsheetButtonClicked(ev)"
-                    data-hotkey="s"
+                    data-hotkey="t"
                 >
                     <i class="fa fa-table" />
                 </button>

--- a/spreadsheet_oca/static/src/spreadsheet/pivot_controller.xml
+++ b/spreadsheet_oca/static/src/spreadsheet/pivot_controller.xml
@@ -12,7 +12,7 @@
                 t-on-click="onSpreadsheetButtonClicked"
                 aria-label="Add to spreadsheet"
                 t-att-disabled="disableSpreadsheetInsertion()"
-                data-hotkey="s"
+                data-hotkey="t"
             />
         </xpath>
     </t>


### PR DESCRIPTION
The hotkey **s** is used by save, so this hotkey is overlapping with this one on tree views.

To solve this, it is changed referring to the icon used in the button (**t**able).

cc @Tecnativa

ping @pedrobaeza @victoralmau 