### PR TITLE
[17.0][FIX] spreadsheet_oca: fix patch to apply setup correctly

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/chart_panels.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/chart_panels.esm.js
@@ -14,7 +14,7 @@ const {
   GaugeChartConfigPanel,
 } = spreadsheet.components;
 
-const menuChartProps = {
+const menuChartProps = () => ({
   setup() {
     super.setup(...arguments);
     this.menus = useService("menu");
@@ -78,21 +78,21 @@ const menuChartProps = {
       },
     };
   },
-};
+});
 
-patch(LineBarPieConfigPanel.prototype, menuChartProps);
+patch(LineBarPieConfigPanel.prototype, menuChartProps());
 LineBarPieConfigPanel.components = {
   ...LineBarPieConfigPanel.components,
   Many2XAutocomplete,
 };
 
-patch(ScorecardChartConfigPanel.prototype, menuChartProps);
+patch(ScorecardChartConfigPanel.prototype, menuChartProps());
 ScorecardChartConfigPanel.components = {
   ...ScorecardChartConfigPanel.components,
   Many2XAutocomplete,
 };
 
-patch(GaugeChartConfigPanel.prototype, menuChartProps);
+patch(GaugeChartConfigPanel.prototype, menuChartProps());
 GaugeChartConfigPanel.components = {
   ...GaugeChartConfigPanel.components,
   Many2XAutocomplete,


### PR DESCRIPTION
Since the patch if you reopen a graph panel the ranges are missing but correctly stored in the model. 
This PR fix the issue.
@Tecnativa TT60939
@CarlosRoca13