### PR TITLE
[18.0][FIX] spreadsheet_oca: Remove duplicated charts that are throwing errors.

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/odoo_panels.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/odoo_panels.esm.js
@@ -1,12 +1,7 @@
-import * as spreadsheet from "@odoo/o-spreadsheet";
-
 import {Domain} from "@web/core/domain";
 import {Many2XAutocomplete} from "@web/views/fields/relational_utils";
 import {_t} from "@web/core/l10n/translation";
 import {useService} from "@web/core/utils/hooks";
-
-const {chartSidePanelComponentRegistry, chartSubtypeRegistry} = spreadsheet.registries;
-const {PieChartDesignPanel} = spreadsheet.components;
 const {Component} = owl;
 
 export class OdooPanel extends Component {
@@ -82,83 +77,3 @@ class OdooStackablePanel extends OdooPanel {
     }
 }
 OdooStackablePanel.template = "spreadsheet_oca.OdooStackablePanel";
-
-chartSidePanelComponentRegistry
-    .add("odoo_line", {
-        configuration: OdooStackablePanel,
-        design: PieChartDesignPanel,
-    })
-    .add("odoo_bar", {
-        configuration: OdooStackablePanel,
-        design: PieChartDesignPanel,
-    })
-    .add("odoo_pie", {
-        configuration: OdooPanel,
-        design: PieChartDesignPanel,
-    });
-
-chartSubtypeRegistry.add("odoo_line", {
-    matcher: (definition) =>
-        definition.type === "odoo_line" && !definition.stacked && !definition.fillArea,
-    subtypeDefinition: {stacked: false, fillArea: false},
-    displayName: _t("Line"),
-    chartSubtype: "odoo_line",
-    chartType: "odoo_line",
-    category: "line",
-    preview: "o-spreadsheet-ChartPreview.LINE_CHART",
-});
-chartSubtypeRegistry.add("odoo_stacked_line", {
-    matcher: (definition) =>
-        definition.type === "odoo_line" && definition.stacked && !definition.fillArea,
-    subtypeDefinition: {stacked: true, fillArea: false},
-    displayName: _t("Stacked Line"),
-    chartSubtype: "odoo_stacked_line",
-    chartType: "odoo_line",
-    category: "line",
-    preview: "o-spreadsheet-ChartPreview.STACKED_LINE_CHART",
-});
-chartSubtypeRegistry.add("odoo_area", {
-    matcher: (definition) =>
-        definition.type === "odoo_line" && !definition.stacked && definition.fillArea,
-    subtypeDefinition: {stacked: false, fillArea: true},
-    displayName: _t("Area"),
-    chartSubtype: "odoo_area",
-    chartType: "odoo_line",
-    category: "area",
-    preview: "o-spreadsheet-ChartPreview.AREA_CHART",
-});
-chartSubtypeRegistry.add("odoo_stacked_area", {
-    matcher: (definition) =>
-        definition.type === "odoo_line" && definition.stacked && definition.fillArea,
-    subtypeDefinition: {stacked: true, fillArea: true},
-    displayName: _t("Stacked Area"),
-    chartSubtype: "odoo_stacked_area",
-    chartType: "odoo_line",
-    category: "area",
-    preview: "o-spreadsheet-ChartPreview.STACKED_AREA_CHART",
-});
-chartSubtypeRegistry.add("odoo_bar", {
-    matcher: (definition) => definition.type === "odoo_bar" && !definition.stacked,
-    subtypeDefinition: {stacked: false},
-    displayName: _t("Column"),
-    chartSubtype: "odoo_bar",
-    chartType: "odoo_bar",
-    category: "column",
-    preview: "o-spreadsheet-ChartPreview.COLUMN_CHART",
-});
-chartSubtypeRegistry.add("odoo_stacked_bar", {
-    matcher: (definition) => definition.type === "odoo_bar" && definition.stacked,
-    subtypeDefinition: {stacked: true},
-    displayName: _t("Stacked Column"),
-    chartSubtype: "odoo_stacked_bar",
-    chartType: "odoo_bar",
-    category: "column",
-    preview: "o-spreadsheet-ChartPreview.STACKED_COLUMN_CHART",
-});
-chartSubtypeRegistry.add("odoo_pie", {
-    displayName: _t("Pie"),
-    chartSubtype: "odoo_pie",
-    chartType: "odoo_pie",
-    category: "pie",
-    preview: "o-spreadsheet-ChartPreview.PIE_CHART",
-});


### PR DESCRIPTION
Removed duplicated charts:
<img width="335" height="787" alt="image" src="https://github.com/user-attachments/assets/c73430b6-963e-4d76-bca5-dc54c8fc1ebb" />


cc @Tecnativa TT58043

ping @pedrobaeza @christian-ramos-tecnativa 