### PR TITLE
[18.0][FIX] spreadsheet_oca: Use the correct graphs depending on the type of each one

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/chart_panel.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/chart_panel.esm.js
@@ -1,41 +1,67 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import {patch} from "@web/core/utils/patch";
+import {onWillUpdateProps} from "@odoo/owl";
 
-const {chartRegistry} = spreadsheet.registries;
-const {ChartPanel} = spreadsheet.components;
-export function isOdooKey(code) {
-    return code.startsWith("odoo_");
-}
+const {chartSubtypeRegistry} = spreadsheet.registries;
+const {ChartTypePicker} = spreadsheet.components;
 
-patch(ChartPanel.prototype, {
-    get chartTypes() {
-        return this.filterChartTypes(isOdooKey(this.getChartDefinition().type));
+const ODOO_PREFIX = "odoo_";
+const isOdooKey = (key) => key?.startsWith(ODOO_PREFIX);
+
+const groupByCategory = (items) =>
+    items.reduce((acc, item) => {
+        (acc[item.category] ||= []).push(item);
+        return acc;
+    }, {});
+
+const getFigureDefinition = (env, figureId) =>
+    env.model.getters.getChartDefinition(figureId);
+
+patch(ChartTypePicker.prototype, {
+    setup() {
+        super.setup();
+        const refresh = (figureId) => this.filterCategoriesChartType(figureId);
+        refresh(this.props.figureId);
+        onWillUpdateProps((nextProps) => refresh(nextProps.figureId));
     },
 
-    filterChartTypes(isOdoo) {
-        var result = {};
-        for (const key of chartRegistry.getKeys()) {
-            if ((isOdoo && isOdooKey(key)) || (!isOdoo && !isOdooKey(key))) {
-                result[key] = chartRegistry.get(key).name;
+    getChartTypes(isOdoo) {
+        const result = {};
+        for (const key of chartSubtypeRegistry.getKeys()) {
+            if (isOdoo === isOdooKey(key)) {
+                result[key] = chartSubtypeRegistry.get(key).name;
             }
         }
         return result;
     },
     onTypeChange(type) {
-        if (isOdooKey(this.getChartDefinition().type)) {
-            const definition = {
-                stacked: false,
-                verticalAxisPosition: "left",
-                ...this.env.model.getters.getChartDefinition(this.figureId),
-                type,
-            };
-            this.env.model.dispatch("UPDATE_CHART", {
-                definition,
-                id: this.figureId,
-                sheetId: this.env.model.getters.getActiveSheetId(),
-            });
-        } else {
-            super.onTypeChange(type);
+        const {env} = this;
+        const figureId = this.props.figureId;
+        const current = getFigureDefinition(env, figureId);
+        if (!isOdooKey(current.type)) {
+            return super.onTypeChange(type);
         }
+        const newChartInfo = chartSubtypeRegistry.get(type);
+        const definition = {
+            verticalAxisPosition: "left",
+            ...current,
+            ...newChartInfo.subtypeDefinition,
+            type: newChartInfo.chartType,
+        };
+        env.model.dispatch("UPDATE_CHART", {
+            definition,
+            id: figureId,
+            sheetId: env.model.getters.getActiveSheetId(),
+        });
+        this.closePopover();
+    },
+    filterCategoriesChartType(figureId) {
+        const {env} = this;
+        const definition = getFigureDefinition(env, figureId);
+        const isOdoo = isOdooKey(definition.type);
+        const registryItems = chartSubtypeRegistry
+            .getAll()
+            .filter((item) => isOdoo === isOdooKey(item.chartType));
+        this.chartTypeByCategories = groupByCategory(registryItems);
     },
 });

--- a/spreadsheet_oca/static/src/spreadsheet/bundle/odoo_panels.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/odoo_panels.esm.js
@@ -1,7 +1,12 @@
+import * as spreadsheet from "@odoo/o-spreadsheet";
+
 import {Domain} from "@web/core/domain";
 import {Many2XAutocomplete} from "@web/views/fields/relational_utils";
 import {_t} from "@web/core/l10n/translation";
 import {useService} from "@web/core/utils/hooks";
+
+const {chartSidePanelComponentRegistry, chartSubtypeRegistry} = spreadsheet.registries;
+const {PieChartDesignPanel} = spreadsheet.components;
 const {Component} = owl;
 
 export class OdooPanel extends Component {
@@ -77,3 +82,83 @@ class OdooStackablePanel extends OdooPanel {
     }
 }
 OdooStackablePanel.template = "spreadsheet_oca.OdooStackablePanel";
+
+chartSidePanelComponentRegistry
+    .add("odoo_line", {
+        configuration: OdooStackablePanel,
+        design: PieChartDesignPanel,
+    })
+    .add("odoo_bar", {
+        configuration: OdooStackablePanel,
+        design: PieChartDesignPanel,
+    })
+    .add("odoo_pie", {
+        configuration: OdooPanel,
+        design: PieChartDesignPanel,
+    });
+
+chartSubtypeRegistry.add("odoo_line", {
+    matcher: (definition) =>
+        definition.type === "odoo_line" && !definition.stacked && !definition.fillArea,
+    subtypeDefinition: {stacked: false, fillArea: false},
+    displayName: _t("Line"),
+    chartSubtype: "odoo_line",
+    chartType: "odoo_line",
+    category: "line",
+    preview: "o-spreadsheet-ChartPreview.LINE_CHART",
+});
+chartSubtypeRegistry.add("odoo_stacked_line", {
+    matcher: (definition) =>
+        definition.type === "odoo_line" && definition.stacked && !definition.fillArea,
+    subtypeDefinition: {stacked: true, fillArea: false},
+    displayName: _t("Stacked Line"),
+    chartSubtype: "odoo_stacked_line",
+    chartType: "odoo_line",
+    category: "line",
+    preview: "o-spreadsheet-ChartPreview.STACKED_LINE_CHART",
+});
+chartSubtypeRegistry.add("odoo_area", {
+    matcher: (definition) =>
+        definition.type === "odoo_line" && !definition.stacked && definition.fillArea,
+    subtypeDefinition: {stacked: false, fillArea: true},
+    displayName: _t("Area"),
+    chartSubtype: "odoo_area",
+    chartType: "odoo_line",
+    category: "area",
+    preview: "o-spreadsheet-ChartPreview.AREA_CHART",
+});
+chartSubtypeRegistry.add("odoo_stacked_area", {
+    matcher: (definition) =>
+        definition.type === "odoo_line" && definition.stacked && definition.fillArea,
+    subtypeDefinition: {stacked: true, fillArea: true},
+    displayName: _t("Stacked Area"),
+    chartSubtype: "odoo_stacked_area",
+    chartType: "odoo_line",
+    category: "area",
+    preview: "o-spreadsheet-ChartPreview.STACKED_AREA_CHART",
+});
+chartSubtypeRegistry.add("odoo_bar", {
+    matcher: (definition) => definition.type === "odoo_bar" && !definition.stacked,
+    subtypeDefinition: {stacked: false},
+    displayName: _t("Column"),
+    chartSubtype: "odoo_bar",
+    chartType: "odoo_bar",
+    category: "column",
+    preview: "o-spreadsheet-ChartPreview.COLUMN_CHART",
+});
+chartSubtypeRegistry.add("odoo_stacked_bar", {
+    matcher: (definition) => definition.type === "odoo_bar" && definition.stacked,
+    subtypeDefinition: {stacked: true},
+    displayName: _t("Stacked Column"),
+    chartSubtype: "odoo_stacked_bar",
+    chartType: "odoo_bar",
+    category: "column",
+    preview: "o-spreadsheet-ChartPreview.STACKED_COLUMN_CHART",
+});
+chartSubtypeRegistry.add("odoo_pie", {
+    displayName: _t("Pie"),
+    chartSubtype: "odoo_pie",
+    chartType: "odoo_pie",
+    category: "pie",
+    preview: "o-spreadsheet-ChartPreview.PIE_CHART",
+});


### PR DESCRIPTION
cc @Tecnativa TT58043

ping @pedrobaeza @christian-ramos-tecnativa @chrisandrewmann

Before these changes, all existing chart types were displayed in the selector.
<img width="335" height="787" alt="image" src="https://github.com/user-attachments/assets/3c934817-d878-4e35-8466-2fbc15627700" />

With these changes, the table type is taken into account, whether it is inserted from Odoo or from the spreadsheet itself, to determine which chart types are usable and which are not.
<img width="1220" height="893" alt="image" src="https://github.com/user-attachments/assets/7132e5a1-f558-461e-b581-c215bc1ec89f" />
<img width="1225" height="918" alt="image" src="https://github.com/user-attachments/assets/8c14d2af-b878-4d25-a72c-960d16683e47" />
