### PR TITLE
[18.0][FIX] spreadsheet_oca: Error linking chart to Odoo menu

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/chart_panels.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/chart_panels.esm.js
@@ -19,19 +19,15 @@ const menuChartProps = () => ({
         this.menus = useService("menu");
     },
     get menuProps() {
-        const menu = this.env.model.getters.getChartOdooMenu(this.props.figureId);
-        var result = {
+        return {
             fieldString: _t("Menu Items"),
             resModel: "ir.ui.menu",
             update: this.updateMenu.bind(this),
             activeActions: {},
             getDomain: this.getDomain.bind(this),
+            placeholder: _t("Select a menu..."),
+            value: this.menuId ? this.menuId[1] : "",
         };
-        if (menu) {
-            result.value = menu.name;
-            result.id = menu.id;
-        }
-        return result;
     },
 
     getDomain() {

--- a/spreadsheet_oca/static/src/spreadsheet/bundle/odoo_panels.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/odoo_panels.esm.js
@@ -14,19 +14,15 @@ export class OdooPanel extends Component {
         this.menus = useService("menu");
     }
     get menuProps() {
-        const menu = this.env.model.getters.getChartOdooMenu(this.props.figureId);
-        var result = {
+        return {
             fieldString: _t("Menu Items"),
             resModel: "ir.ui.menu",
             update: this.updateMenu.bind(this),
             activeActions: {},
             getDomain: this.getDomain.bind(this),
+            placeholder: _t("Select a menu..."),
+            value: this.menuId ? this.menuId[1] : "",
         };
-        if (menu) {
-            result.value = menu.name;
-            result.id = menu.id;
-        }
-        return result;
     }
     getDomain() {
         const menus = this.menus


### PR DESCRIPTION
Steps to reproduce the error:
1. Set debug=assets
2. Add a chart to spreadsheet
3. In "Link to Odoo menu" section select a record

An error will be thrown

![Error](https://github.com/user-attachments/assets/48e00245-f021-466d-9350-0cdbb2ea99fe)

cc @Tecnativa

ping @christian-ramos-tecnativa @pedrobaeza 