### PR TITLE
[18.0][FIX] spreadsheet_oca: Take care about variables on domain

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
@@ -120,7 +120,7 @@ export class PivotPanelDisplay extends Component {
     editDomain() {
         this.dialog.add(DomainSelectorDialog, {
             resModel: this.store.definition.model,
-            domain: this.store.definition.domain,
+            domain: this.domain,
             readonly: false,
             isDebugMode: Boolean(this.env.debug),
             onConfirm: this.onSelectDomain.bind(this),

--- a/spreadsheet_oca/static/src/spreadsheet/graph_controller.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/graph_controller.esm.js
@@ -12,10 +12,11 @@ patch(GraphRenderer.prototype, {
                     default_datasource_name: this.model.metaData.title,
                     default_import_data: {
                         mode: "graph",
-                        metaData: JSON.parse(JSON.stringify(this.model.metaData)),
-                        searchParams: JSON.parse(
-                            JSON.stringify(this.model.searchParams)
-                        ),
+                        metaData: this.model.metaData,
+                        searchParams: {
+                            ...this.model.searchParams,
+                            domain: this.env.searchModel.domainString,
+                        },
                     },
                 },
             }

--- a/spreadsheet_oca/static/src/spreadsheet/list_renderer.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/list_renderer.esm.js
@@ -32,7 +32,7 @@ patch(ListRenderer.prototype, {
                         mode: "list",
                         metaData: {
                             model: model.resModel,
-                            domain: model.domain,
+                            domain: this.env.searchModel.domainString,
                             orderBy: model.orderBy,
                             context: omit(
                                 model.searchParams?.context || {},

--- a/spreadsheet_oca/static/src/spreadsheet/pivot_controller.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/pivot_controller.esm.js
@@ -54,10 +54,11 @@ patch(PivotRenderer.prototype, {
                     default_can_be_dynamic: false,
                     default_import_data: {
                         mode: "pivot",
-                        metaData: JSON.parse(JSON.stringify(this.model.metaData)),
-                        searchParams: JSON.parse(
-                            JSON.stringify(this.model.searchParams)
-                        ),
+                        metaData: this.model.metaData,
+                        searchParams: {
+                            ...this.model.searchParams,
+                            domain: this.env.searchModel.domainString,
+                        },
                     },
                 },
             }


### PR DESCRIPTION
This commit fixes the problem reported in this issue: https://github.com/OCA/spreadsheet/issues/96

Before these changes, the domain was taking the processed domain value, so it was using the value for the logged-in user. For example, if the uid variable was used, it was replaced with the user's ID and thus passed that way to the spreadsheet domains.

After these changes, the domain sent to the spreadsheet is the unprocessed domain, so the variables are preserved and remain fully usable.

cc @Tecnativa 

ping @pedrobaeza @christian-ramos-tecnativa 