### PR TITLE
[18.0][FIX] spreadsheet_oca: Error thrown when pivot is sorted

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/filter_panel_datasources.esm.js
@@ -101,13 +101,10 @@ export class PivotPanelDisplay extends Component {
         const sortedColumn = this.store.definition.sortedColumn;
         const orderTranslate =
             sortedColumn.order === "asc" ? _t("ascending") : _t("descending");
-        let label = null;
-        if (sortedColumn.measure) {
-            const measure = this.PivotDataSource.getMeasure(sortedColumn.measure);
-            label = measure ? measure.displayName : sortedColumn.measure;
-        } else if (sortedColumn.groupBy) {
-            label = this.PivotDataSource.getFormattedGroupBy(sortedColumn.groupBy);
-        }
+        const measure = this.store.definition.measures.find(
+            (m) => m.fieldName === sortedColumn.measure
+        );
+        const label = this.PivotDataSource.getMeasure(measure.id).displayName;
         return `${label} (${orderTranslate})`;
     }
     get lastUpdate() {


### PR DESCRIPTION
When a pivot has a sort defined and the data of the pivot is opened an error is thrown because the data is not processed correctly.

By doing this changes, we adapt the code to the new way of process the pivot data and the error does not being thrown anymore.

cc @Tecnativa TT61581

ping @pedrobaeza @christian-ramos-tecnativa 