### PR TITLE
[18.0][IMP] spreadsheet_oca: Add new features to relation filters

### DIFF
--- a/spreadsheet_oca/models/__init__.py
+++ b/spreadsheet_oca/models/__init__.py
@@ -1,3 +1,4 @@
+from . import ir_model
 from . import spreadsheet_abstract
 from . import spreadsheet_spreadsheet_tag
 from . import spreadsheet_spreadsheet

--- a/spreadsheet_oca/models/ir_model.py
+++ b/spreadsheet_oca/models/ir_model.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    @api.model
+    def has_parent_relation(self, model_name):
+        """Return if the model has a parent relation."""
+        model = self.env.get(model_name)
+        if model is None or not model.has_access("read"):
+            return False
+        return model._parent_name in model._fields

--- a/spreadsheet_oca/static/src/spreadsheet/bundle/filter.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/filter.esm.js
@@ -1,10 +1,15 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import {Component, onWillStart, useState} from "@odoo/owl";
-
+import {Domain} from "@web/core/domain";
+import {DomainSelector} from "@web/core/domain_selector/domain_selector";
+import {DomainSelectorDialog} from "@web/core/domain_selector_dialog/domain_selector_dialog";
 import {FilterValue} from "@spreadsheet/global_filters/components/filter_value/filter_value";
 import {ModelFieldSelector} from "@web/core/model_field_selector/model_field_selector";
 import {ModelSelector} from "@web/core/model_selector/model_selector";
+import {MultiRecordSelector} from "@web/core/record_selectors/multi_record_selector";
 import {RELATIVE_DATE_RANGE_TYPES} from "@spreadsheet/helpers/constants";
+const {Checkbox} = spreadsheet.components;
+import {user} from "@web/core/user";
 
 import {_t} from "@web/core/l10n/translation";
 import {globalFiltersFieldMatchers} from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
@@ -63,25 +68,42 @@ sidePanelRegistry.add("FilterPanel", {
 
 export class EditFilterPanel extends Component {
     setup() {
-        this.filterId = this.props.filter;
+        this.filterId = this.props.filter.id;
         this.orm = useService("orm");
+        this.nameService = useService("name");
+        this.dialog = useService("dialog");
         this.state = useState({
             label: this.props.filter.label,
             type: this.props.filter.type,
-            defaultValue: this.props.filter.defaultValue,
+            defaultValue: this.props.filter.defaultValue || [],
+            defaultValueDisplayNames: this.props.filter.defaultValueDisplayNames || [],
             rangeType: this.props.filter.rangeType || "year",
-            modelName: {technical: this.props.filter.modelName, label: null},
+            modelData: {technical: this.props.filter.modelName, label: null},
             objects: {},
+            includeChildren: this.props.filter.includeChildren,
+            domainOfAllowedValues: this.props.filter.domainOfAllowedValues,
+            valuesRestricted: Boolean(this.props.filter.domainOfAllowedValues?.length),
         });
         this.relativeDateRangeTypes = RELATIVE_DATE_RANGE_TYPES;
         onWillStart(this.willStart.bind(this));
     }
     async willStart() {
-        if (this.state.modelName.technical !== undefined) {
+        if (this.state.modelData.technical !== undefined) {
+            const technicalName = this.state.modelData.technical;
             const modelLabel = await this.orm.call("ir.model", "display_name_for", [
-                [this.state.modelName.technical],
+                [technicalName],
             ]);
-            this.state.modelName.label = modelLabel[0] && modelLabel[0].display_name;
+            this.state.modelData.label = modelLabel[0] && modelLabel[0].display_name;
+            if (this.state.includeChildren) {
+                this.state.modelData.hasParentRelation = true;
+            } else {
+                const hasParentRelation = await this.orm.call(
+                    "ir.model",
+                    "has_parent_relation",
+                    [technicalName]
+                );
+                this.state.modelData.hasParentRelation = hasParentRelation;
+            }
         }
         var ModelFields = [];
         for (var [objectType, objectClass] of Object.entries(
@@ -132,9 +154,46 @@ export class EditFilterPanel extends Component {
     onChangeFieldMatchOffset(object, ev) {
         this.state.objects[object.id].fieldMatch.offset = parseInt(ev.target.value, 10);
     }
-    onModelSelected(ev) {
-        this.state.modelName.technical = ev.technical;
-        this.state.modelName.label = ev.label;
+    async onModelSelected(ev) {
+        this.state.modelData.technical = ev.technical;
+        this.state.modelData.label = ev.label;
+        this.state.modelData.hasParentRelation = await this.orm.call(
+            "ir.model",
+            "has_parent_relation",
+            [ev.technical]
+        );
+        this.state.domainOfAllowedValues = [];
+    }
+    async onRecordsSelected(resIds) {
+        const defaultValueDisplayNames = await this.nameService.loadDisplayNames(
+            this.state.modelData.technical,
+            resIds
+        );
+        this.state.defaultValue = resIds;
+        this.state.defaultValueDisplayNames = Object.values(defaultValueDisplayNames);
+    }
+    onUpdateDomain(domain) {
+        this.state.domainOfAllowedValues = domain;
+    }
+    getCorrectDomain() {
+        const domain = this.state.domainOfAllowedValues;
+        if (domain) {
+            return new Domain(domain).toList(user.context);
+        }
+        return [];
+    }
+    changeDomainRestriction(value) {
+        this.state.valuesRestricted = value;
+        this.state.domainOfAllowedValues = [];
+    }
+    editDomain() {
+        this.dialog.add(DomainSelectorDialog, {
+            resModel: this.state.modelData.technical,
+            domain: this.getCorrectDomain(),
+            readonly: false,
+            isDebugMode: Boolean(this.env.debug),
+            onConfirm: this.onUpdateDomain.bind(this),
+        });
     }
     onDateRangeChange(ev) {
         this.state.rangeType = ev.target.value;
@@ -148,10 +207,13 @@ export class EditFilterPanel extends Component {
         const filter = {
             id: this.props.filter.id || uuidGenerator.uuidv4(),
             type: this.state.type,
-            label: this.state.label,
+            label: this.state.label || "",
             defaultValue: this.state.defaultValue,
+            defaultValueDisplayNames: this.state.defaultValueDisplayNames,
             rangeType: this.state.rangeType,
-            modelName: this.state.modelName.technical,
+            modelName: this.state.modelData.technical,
+            includeChildren: this.state.includeChildren,
+            domainOfAllowedValues: this.state.domainOfAllowedValues,
         };
         const filterMatching = {};
         Object.values(this.state.objects).forEach((object) => {
@@ -227,7 +289,13 @@ export class EditFilterPanel extends Component {
 }
 
 EditFilterPanel.template = "spreadsheet_oca.EditFilterPanel";
-EditFilterPanel.components = {ModelSelector, ModelFieldSelector};
+EditFilterPanel.components = {
+    Checkbox,
+    DomainSelector,
+    ModelSelector,
+    ModelFieldSelector,
+    MultiRecordSelector,
+};
 
 sidePanelRegistry.add("EditFilterPanel", {
     title: "Edit Filter",

--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet.xml
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet.xml
@@ -243,17 +243,75 @@
                 t-model="state.defaultValue"
             />
         </div>
-
-        <div class="o_spreadsheet_oca_filter" t-if="state.type === 'relation'">
-            <div class="spreadsheet_oca_filter_label">Related model</div>
-            <div class="spreadsheet_oca_filter_value">
-                <ModelSelector
-                    value="state.modelName.label or ''"
-                    models="models"
-                    onModelSelected.bind="onModelSelected"
+        <t t-if="state.type === 'relation'">
+            <div class="o_spreadsheet_oca_filter">
+                <div class="spreadsheet_oca_filter_label">Related model</div>
+                <div class="spreadsheet_oca_filter_value">
+                    <ModelSelector
+                        value="state.modelData.label or ''"
+                        models="models"
+                        onModelSelected.bind="onModelSelected"
+                    />
+                </div>
+                <Checkbox
+                    t-if="state.modelData.hasParentRelation"
+                    name="'includeChildren'"
+                    label.translate="Include children"
+                    value="state.includeChildren"
+                    onChange="(value) => this.state.includeChildren = value"
                 />
             </div>
-        </div>
+            <t t-if="state.modelData.technical">
+                <div class="o_spreadsheet_oca_filter">
+                    <div class="spreadsheet_oca_filter_label">Default value</div>
+                    <div
+                        class="spreadsheet_oca_filter_value"
+                        t-if="!(state.modelData.technical === 'res.users' and state.defaultValue === 'current_user')"
+                    >
+                        <MultiRecordSelector
+                            resModel="state.modelData.technical"
+                            resIds="state.defaultValue || []"
+                            t-key="state.modelData.technical"
+                            placeholder="''"
+                            domain="getCorrectDomain()"
+                            update.bind="onRecordsSelected"
+                        />
+                    </div>
+                    <div
+                        class="spreadsheet_oca_filter_value"
+                        t-if="state.modelData.technical === 'res.users'"
+                    >
+                        <Checkbox
+                            className="'mb-1'"
+                            label.translate="Automatically filter on the current user"
+                            onChange="(value) => this.state.defaultValue = value ? 'current_user' : []"
+                            value="state.defaultValue === 'current_user'"
+                        />
+                    </div>
+                </div>
+                <div class="o_spreadsheet_oca_filter">
+                    <div class="spreadsheet_oca_filter_label">Possible values</div>
+                    <div class="spreadsheet_oca_filter_value">
+                        <Checkbox
+                            className="'mb-1'"
+                            label.translate="Restrict values with a domain"
+                            onChange.bind="changeDomainRestriction"
+                            value="state.valuesRestricted"
+                        />
+                    </div>
+                    <t t-if="state.valuesRestricted">
+                        <DomainSelector
+                            resModel="state.modelData.technical"
+                            domain="getCorrectDomain()"
+                            t-key="'filter_' + filterId"
+                        />
+                        <div class="btn btn-link" t-on-click="editDomain">
+                            Edit domain
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
         <div
             class="o_spreadsheet_oca_filter"
             t-foreach="Object.values(state.objects)"
@@ -296,7 +354,7 @@
                 </select>
             </div>
         </div>
-        <div class="o-sidePanelButtons">
+        <div class="o-sidePanelButtons justify-content-center">
             <button t-on-click="onRemove" class="btn btn-danger">Remove</button>
             <button t-on-click="onCancel" class="btn btn-warning">Cancel</button>
             <button t-on-click="onSave" class="btn btn-primary">Save</button>


### PR DESCRIPTION
With this changes we are adding:
1. Include children records when it is possible
2. Add default values for the filter
3. If the model is for users allow set the current user by default
4. Allow to restrict values with a domain

cc @Tecnativa TT61649

ping @pedrobaeza @christian-ramos-tecnativa 