### PR TITLE
[18.0][FIX] spreadsheet_oca: inherit parent components in SpreadsheetControlPanel

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_controlpanel.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_controlpanel.esm.js
@@ -46,5 +46,6 @@ SpreadsheetControlPanel.props = {
     record: Object,
 };
 SpreadsheetControlPanel.components = {
+    ...ControlPanel.components,
     SpreadsheetName,
 };


### PR DESCRIPTION
## Summary

`SpreadsheetControlPanel` extends `ControlPanel` but overrides its `static components` property with only `SpreadsheetName`, losing `Dropdown` and `DropdownItem` that the parent template (`web.ControlPanel`) uses.

This causes:
```
OwlError: Cannot find the definition of component "Dropdown"
```

The error occurs when opening a spreadsheet from certain navigation paths (e.g., from a form view or a custom action), where the parent template's Dropdown component is needed.

## Fix

Spread parent components before adding custom ones:

```js
// Before (bug)
SpreadsheetControlPanel.components = {
    SpreadsheetName,
};

// After (fix)  
SpreadsheetControlPanel.components = {
    ...ControlPanel.components,
    SpreadsheetName,
};
```

This follows the same pattern used for `SpreadsheetControlPanel.props` which already spreads `ControlPanel.props`.

## Test plan

- [x] Open a spreadsheet from the kanban view — works before and after
- [x] Open a spreadsheet from a form view (e.g., linked record) — fails before, works after
- [x] Edit spreadsheet name in the control panel — works
- [x] Breadcrumb navigation — works