### PR TITLE
[19.0][FIX] spreadsheet_oca: fix breadcrumbs Owl error

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_controlpanel.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_controlpanel.esm.js
@@ -46,5 +46,6 @@ SpreadsheetControlPanel.props = {
     record: Object,
 };
 SpreadsheetControlPanel.components = {
+    ...ControlPanel.components,
     SpreadsheetName,
 };


### PR DESCRIPTION
This PR is basically a cherry-pick of #112 , which solves the problem on #124 for v19, since #112 fixes the issue on v18

The solution itlself is really simple