### PR TITLE
[19.0][IMP] spreadsheet_dashboard_oca: manage dashboard share links

### DIFF
--- a/spreadsheet_dashboard_oca/README.rst
+++ b/spreadsheet_dashboard_oca/README.rst
@@ -33,12 +33,33 @@ Spreadsheet Dashboard Oca
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows to edit spreadsheet dashboards using OCA Spreadsheet
-editor.
+editor. It also allows to manage the public share links of those
+dashboards: list, copy, and revoke them. Dashboard admins can manage the
+shares created by any user.
 
 **Table of contents**
 
 .. contents::
    :local:
+
+Configuration
+=============
+
+Users can only see and revoke the shares they created. Users in the
+"Dashboards / Admin" group
+(spreadsheet_dashboard.group_dashboard_manager) can see and revoke the
+shares created by any user.
+
+Usage
+=====
+
+- Open the "Dashboards" app (Rapor Panelleri).
+- Open a dashboard and click on the **Share** button.
+- Click on **Manage shares** to list every share link of the dashboard.
+- Use the copy button to copy a link, or click **Revoke** to make a link
+  return a 404 error.
+- A badge next to the dashboard name in the sidebar shows the number of
+  active shares.
 
 Bug Tracker
 ===========

--- a/spreadsheet_dashboard_oca/__manifest__.py
+++ b/spreadsheet_dashboard_oca/__manifest__.py
@@ -4,8 +4,9 @@
 {
     "name": "Spreadsheet Dashboard Oca",
     "summary": """
-        Use OCA Spreadsheets on dashboards configuration""",
-    "version": "19.0.1.0.0",
+        Use OCA Spreadsheets on dashboards configuration and manage
+        dashboard share links""",
+    "version": "19.0.2.0.0",
     "license": "AGPL-3",
     "author": "CreuBlanca,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/spreadsheet",
@@ -15,6 +16,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/ir_rule.xml",
         "wizards/spreadsheet_spreadsheet_import.xml",
         "wizards/spreadsheet_to_dashboard.xml",
         "views/spreadsheet_dashboard_group_views.xml",
@@ -26,8 +28,12 @@
             (
                 "after",
                 "spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js",
-                "spreadsheet_dashboard_oca/static/src/bundle/*.js",
+                "spreadsheet_dashboard_oca/static/src/bundle/**/*.js",
             ),
+            "spreadsheet_dashboard_oca/static/src/bundle/**/*.xml",
+        ],
+        "web.assets_unit_tests": [
+            "spreadsheet_dashboard_oca/static/tests/**/*",
         ],
     },
 }

--- a/spreadsheet_dashboard_oca/i18n/spreadsheet_dashboard_oca.pot
+++ b/spreadsheet_dashboard_oca/i18n/spreadsheet_dashboard_oca.pot
@@ -14,8 +14,20 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
+msgid "Actions"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_dashboard__active
 msgid "Active"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/dashboard_badge.xml:0
+msgid "Active shares"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
@@ -35,8 +47,25 @@ msgid "Cancel"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
+msgid "Close"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.esm.js:0
+msgid "Copied"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
 #: model_terms:ir.ui.view,arch_db:spreadsheet_dashboard_oca.spreadsheet_dashboard_tree_view
 msgid "Copy"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
+#: model:ir.model,name:spreadsheet_dashboard_oca.model_spreadsheet_dashboard_share
+msgid "Copy of a shared dashboard"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
@@ -50,17 +79,23 @@ msgid "Create dashboard from spreadsheet"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_to_dashboard__create_uid
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
 msgid "Created by"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_to_dashboard__create_date
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
 msgid "Created on"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_spreadsheet_import__dashboard_id
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
 msgid "Dashboard"
 msgstr ""
 
@@ -81,6 +116,7 @@ msgstr ""
 
 #. module: spreadsheet_dashboard_oca
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_dashboard__display_name
+#: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_dashboard_share__display_name
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_spreadsheet_import__display_name
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_to_dashboard__display_name
 msgid "Display Name"
@@ -93,6 +129,7 @@ msgstr ""
 
 #. module: spreadsheet_dashboard_oca
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_dashboard__id
+#: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_dashboard_share__id
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_spreadsheet_import__id
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_to_dashboard__id
 msgid "ID"
@@ -114,6 +151,13 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_button.xml:0
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_button_patch.esm.js:0
+msgid "Manage shares"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
 #: model:ir.model.fields,field_description:spreadsheet_dashboard_oca.field_spreadsheet_dashboard__name
 msgid "Name"
 msgstr ""
@@ -124,9 +168,27 @@ msgid "New dashboard"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
+msgid "No shares yet."
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
+msgid "Revoke"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
 #. odoo-python
 #: code:addons/spreadsheet_dashboard_oca/models/spreadsheet_dashboard.py:0
 msgid "Search operation not supported"
+msgstr ""
+
+#. module: spreadsheet_dashboard_oca
+#. odoo-javascript
+#: code:addons/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml:0
+msgid "Share link"
 msgstr ""
 
 #. module: spreadsheet_dashboard_oca

--- a/spreadsheet_dashboard_oca/models/__init__.py
+++ b/spreadsheet_dashboard_oca/models/__init__.py
@@ -1,1 +1,2 @@
 from . import spreadsheet_dashboard
+from . import spreadsheet_dashboard_share

--- a/spreadsheet_dashboard_oca/models/spreadsheet_dashboard_share.py
+++ b/spreadsheet_dashboard_oca/models/spreadsheet_dashboard_share.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Volkan Tasci
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SpreadsheetDashboardShare(models.Model):
+    _inherit = "spreadsheet.dashboard.share"
+
+    @api.model
+    def action_get_dashboard_shares(self, dashboard_id):
+        """Return the shares of a dashboard the current user can see."""
+        shares = self.search([("dashboard_id", "=", dashboard_id)])
+        return [
+            {
+                "id": share.id,
+                "full_url": share.full_url,
+                "create_date": (
+                    share.create_date.isoformat() if share.create_date else False
+                ),
+                "create_uid": (
+                    share.create_uid.display_name if share.create_uid else False
+                ),
+                "name": share.name,
+            }
+            for share in shares
+        ]
+
+    @api.model
+    def action_unshare(self, share_ids):
+        """Revoke shares. ir.rule limits the user to the shares they may access."""
+        self.browse(share_ids).unlink()
+        return True
+
+    @api.model
+    def action_get_share_counts(self):
+        """Return {dashboard_id: share_count} for shares visible to the user."""
+        counts = self._read_group([], ["dashboard_id"], ["__count"])
+        return {count[0].id: count[1] for count in counts if count[0]}

--- a/spreadsheet_dashboard_oca/readme/CONFIGURE.md
+++ b/spreadsheet_dashboard_oca/readme/CONFIGURE.md
@@ -1,0 +1,3 @@
+Users can only see and revoke the shares they created. Users in the
+"Dashboards / Admin" group (spreadsheet_dashboard.group_dashboard_manager)
+can see and revoke the shares created by any user.

--- a/spreadsheet_dashboard_oca/readme/DESCRIPTION.md
+++ b/spreadsheet_dashboard_oca/readme/DESCRIPTION.md
@@ -1,2 +1,4 @@
 This module allows to edit spreadsheet dashboards using OCA Spreadsheet
-editor.
+editor. It also allows to manage the public share links of those
+dashboards: list, copy, and revoke them. Dashboard admins can manage the
+shares created by any user.

--- a/spreadsheet_dashboard_oca/readme/USAGE.md
+++ b/spreadsheet_dashboard_oca/readme/USAGE.md
@@ -1,0 +1,7 @@
+- Open the "Dashboards" app (Rapor Panelleri).
+- Open a dashboard and click on the **Share** button.
+- Click on **Manage shares** to list every share link of the dashboard.
+- Use the copy button to copy a link, or click **Revoke** to make a link
+  return a 404 error.
+- A badge next to the dashboard name in the sidebar shows the number of
+  active shares.

--- a/spreadsheet_dashboard_oca/security/ir_rule.xml
+++ b/spreadsheet_dashboard_oca/security/ir_rule.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="spreadsheet_dashboard_share_manager_rule" model="ir.rule">
+        <field name="name">spreadsheet.dashboard.share: manager sees all</field>
+        <field name="model_id" ref="model_spreadsheet_dashboard_share" />
+        <field
+            name="groups"
+            eval="[(4, ref('spreadsheet_dashboard.group_dashboard_manager'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+</odoo>

--- a/spreadsheet_dashboard_oca/static/description/index.html
+++ b/spreadsheet_dashboard_oca/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Spreadsheet Dashboard Oca</title>
 <style type="text/css">
 
 /*
@@ -376,21 +376,44 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/spreadsheet/tree/19.0/spreadsheet_dashboard_oca"><img alt="OCA/spreadsheet" src="https://img.shields.io/badge/github-OCA%2Fspreadsheet-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/spreadsheet-19-0/spreadsheet-19-0-spreadsheet_dashboard_oca"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/spreadsheet&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows to edit spreadsheet dashboards using OCA Spreadsheet
-editor.</p>
+editor. It also allows to manage the public share links of those
+dashboards: list, copy, and revoke them. Dashboard admins can manage the
+shares created by any user.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
+<p>Users can only see and revoke the shares they created. Users in the
+“Dashboards / Admin” group
+(spreadsheet_dashboard.group_dashboard_manager) can see and revoke the
+shares created by any user.</p>
+</div>
+<div class="section" id="usage">
+<h2><a class="toc-backref" href="#toc-entry-2">Usage</a></h2>
+<ul class="simple">
+<li>Open the “Dashboards” app (Rapor Panelleri).</li>
+<li>Open a dashboard and click on the <strong>Share</strong> button.</li>
+<li>Click on <strong>Manage shares</strong> to list every share link of the dashboard.</li>
+<li>Use the copy button to copy a link, or click <strong>Revoke</strong> to make a link
+return a 404 error.</li>
+<li>A badge next to the dashboard name in the sidebar shows the number of
+active shares.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/spreadsheet/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -398,15 +421,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
 <ul class="simple">
 <li>CreuBlanca</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
 <ul class="simple">
 <li>Enric Tobella</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
@@ -420,7 +443,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/spreadsheet_dashboard_oca/static/src/bundle/dashboard_badge.esm.js
+++ b/spreadsheet_dashboard_oca/static/src/bundle/dashboard_badge.esm.js
@@ -1,0 +1,34 @@
+import {onWillStart, useState} from "@odoo/owl";
+import {SpreadsheetDashboardAction} from "@spreadsheet_dashboard/bundle/dashboard_action/dashboard_action";
+import {patch} from "@web/core/utils/patch";
+import {useBus} from "@web/core/utils/hooks";
+
+patch(SpreadsheetDashboardAction.prototype, {
+    setup() {
+        super.setup();
+        this.shareCounts = useState({});
+        onWillStart(async () => {
+            await this._loadShareCounts();
+        });
+        useBus(this.env.bus, "dashboards-shares-updated", () =>
+            this._loadShareCounts()
+        );
+    },
+    async _loadShareCounts() {
+        try {
+            const counts = await this.orm.call(
+                "spreadsheet.dashboard.share",
+                "action_get_share_counts",
+                []
+            );
+            Object.assign(this.shareCounts, counts);
+        } catch {
+            // Keep previous counts on failure
+        }
+    },
+    async shareSpreadsheet(data, excelExport) {
+        const url = await super.shareSpreadsheet(data, excelExport);
+        this.env.bus.trigger("dashboards-shares-updated");
+        return url;
+    },
+});

--- a/spreadsheet_dashboard_oca/static/src/bundle/dashboard_badge.xml
+++ b/spreadsheet_dashboard_oca/static/src/bundle/dashboard_badge.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<templates xml:space="preserve">
+  <t
+        t-inherit="spreadsheet_dashboard.DashboardAction.Expanded"
+        t-inherit-mode="extension"
+    >
+        <xpath expr="//div[hasclass('o_dashboard_name')]" position="inside">
+            <span
+                t-if="shareCounts[dashboard.data.id]"
+                t-esc="shareCounts[dashboard.data.id]"
+                class="badge text-bg-secondary ms-1"
+                title="Active shares"
+            />
+        </xpath>
+    </t>
+  <t
+        t-inherit="spreadsheet_dashboard.DashboardAction.Collapsed"
+        t-inherit-mode="extension"
+    >
+        <xpath expr="//div[hasclass('mx-auto')]" position="inside">
+            <span
+                t-if="shareCounts[loader.getActiveDashboard().data.id]"
+                t-esc="shareCounts[loader.getActiveDashboard().data.id]"
+                class="badge text-bg-secondary ms-1"
+                title="Active shares"
+            />
+        </xpath>
+    </t>
+</templates>

--- a/spreadsheet_dashboard_oca/static/src/bundle/share_button.xml
+++ b/spreadsheet_dashboard_oca/static/src/bundle/share_button.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="spreadsheet.ShareButton" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_field_widget')][1]" position="after">
+            <button
+                t-if="isDashboard"
+                class="dropdown-item text-primary"
+                t-on-click="onManageShares"
+            >
+                <i class="fa fa-fw fa-gears me-1" />
+                Manage shares
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/spreadsheet_dashboard_oca/static/src/bundle/share_button_patch.esm.js
+++ b/spreadsheet_dashboard_oca/static/src/bundle/share_button_patch.esm.js
@@ -1,0 +1,30 @@
+import {SpreadsheetShareButton} from "@spreadsheet/components/share_button/share_button";
+import {_t} from "@web/core/l10n/translation";
+import {patch} from "@web/core/utils/patch";
+import {useService} from "@web/core/utils/hooks";
+
+import {ShareManageDialog} from "./share_manage/share_manage_dialog.esm";
+
+const MANAGE_SHARES = _t("Manage shares");
+
+patch(SpreadsheetShareButton.prototype, {
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+        this.isDashboard = Boolean(this.env.services.spreadsheet_dashboard_loader);
+    },
+    onManageShares() {
+        if (!this.isDashboard) {
+            return;
+        }
+        const dashboard =
+            this.env.services.spreadsheet_dashboard_loader.getActiveDashboard();
+        if (!dashboard) {
+            return;
+        }
+        this.dialog.add(ShareManageDialog, {
+            dashboardId: dashboard.data.id,
+            title: `${dashboard.data.name} - ${MANAGE_SHARES}`,
+        });
+    },
+});

--- a/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.esm.js
+++ b/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.esm.js
@@ -1,0 +1,48 @@
+import {Component, onWillStart, useState} from "@odoo/owl";
+import {CopyButton} from "@web/core/copy_button/copy_button";
+import {Dialog} from "@web/core/dialog/dialog";
+import {_t} from "@web/core/l10n/translation";
+import {useService} from "@web/core/utils/hooks";
+
+export class ShareManageDialog extends Component {
+    static template = "spreadsheet_dashboard_oca.ShareManageDialog";
+    static components = {CopyButton, Dialog};
+    static props = {
+        dashboardId: {type: Number},
+        title: {type: String},
+        close: {type: Function, optional: true},
+    };
+
+    setup() {
+        this.copiedText = _t("Copied");
+        this.orm = useService("orm");
+        this.state = useState({shares: [], revoking: 0});
+        onWillStart(async () => {
+            await this._loadShares();
+        });
+    }
+
+    async _loadShares() {
+        this.state.shares = await this.orm.call(
+            "spreadsheet.dashboard.share",
+            "action_get_dashboard_shares",
+            [this.props.dashboardId]
+        );
+    }
+
+    async onRevoke(share) {
+        if (this.state.revoking === share.id) {
+            return;
+        }
+        this.state.revoking = share.id;
+        try {
+            await this.orm.call("spreadsheet.dashboard.share", "action_unshare", [
+                [share.id],
+            ]);
+            this.state.shares = this.state.shares.filter((s) => s.id !== share.id);
+            this.env.bus.trigger("dashboards-shares-updated");
+        } finally {
+            this.state.revoking = 0;
+        }
+    }
+}

--- a/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml
+++ b/spreadsheet_dashboard_oca/static/src/bundle/share_manage/share_manage_dialog.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<templates xml:space="preserve">
+    <t t-name="spreadsheet_dashboard_oca.ShareManageDialog">
+        <Dialog title="props.title" size="'lg'">
+            <p t-if="!state.shares.length" class="text-muted mb-0">
+                No shares yet.
+            </p>
+            <table t-else="" class="table table-sm mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Dashboard</th>
+                        <th>Share link</th>
+                        <th>Created by</th>
+                        <th>Created on</th>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr t-foreach="state.shares" t-as="share" t-key="share.id">
+                        <td t-esc="share.name" />
+                        <td
+                            class="o_field_widget o_readonly_modifier o_field_CopyClipboardChar"
+                        >
+                            <div class="d-grid rounded-2 overflow-hidden">
+                                <span t-esc="share.full_url" />
+                                <CopyButton
+                                    content="share.full_url"
+                                    className="'o_btn_char_copy btn-sm'"
+                                    successText="copiedText"
+                                    icon="'fa-clipboard'"
+                                />
+                            </div>
+                        </td>
+                        <td t-esc="share.create_uid" />
+                        <td t-esc="share.create_date" />
+                        <td class="text-end">
+                            <button
+                                class="btn btn-sm btn-danger"
+                                t-att-disabled="state.revoking === share.id"
+                                t-on-click="() => this.onRevoke(share)"
+                            >
+                                    Revoke
+                                </button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="props.close">Close</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/spreadsheet_dashboard_oca/static/tests/share_manage_dialog.test.js
+++ b/spreadsheet_dashboard_oca/static/tests/share_manage_dialog.test.js
@@ -1,0 +1,79 @@
+import {
+    contains,
+    makeDialogMockEnv,
+    mountWithCleanup,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
+import {describe, expect, test} from "@odoo/hoot";
+
+import {ShareManageDialog} from "@spreadsheet_dashboard_oca/bundle/share_manage/share_manage_dialog";
+
+describe.current.tags("desktop");
+
+const SHARES = [
+    {
+        id: 1,
+        full_url: "http://localhost/dashboard/share/1/token1",
+        create_date: "2026-08-04T10:00:00",
+        create_uid: "Raoul",
+        name: "DeepSeek API Giderleri",
+    },
+    {
+        id: 2,
+        full_url: "http://localhost/dashboard/share/2/token2",
+        create_date: "2026-08-04T11:00:00",
+        create_uid: "Bob",
+        name: "DeepSeek API Giderleri",
+    },
+];
+
+async function mountDialog(env, {shares = SHARES} = {}) {
+    patchWithCleanup(env.services.orm, {
+        async call(model, method) {
+            if (method === "action_get_dashboard_shares") {
+                return shares;
+            }
+            if (method === "action_unshare") {
+                return true;
+            }
+            throw new Error(`Unexpected method: ${method}`);
+        },
+    });
+    await mountWithCleanup(ShareManageDialog, {
+        env,
+        props: {
+            dashboardId: 3,
+            title: "DeepSeek API Giderleri - Manage shares",
+        },
+    });
+}
+
+test("renders the share list", async () => {
+    const env = await makeDialogMockEnv();
+    await mountDialog(env);
+    expect(".modal-header").toHaveText(/Manage shares/);
+    expect("tbody tr").toHaveCount(2);
+    expect("tbody tr").toHaveText(/Raoul/);
+    expect("tbody tr").toHaveText(/Bob/);
+    expect("tbody tr").toHaveText(/dashboard\/share\/1\/token1/);
+});
+
+test("shows empty state when there are no shares", async () => {
+    const env = await makeDialogMockEnv();
+    await mountDialog(env, {shares: []});
+    expect("tbody").toHaveCount(0);
+    expect("body").toHaveText(/No shares yet/);
+});
+
+test("revoke removes the row and notifies the badge", async () => {
+    const env = await makeDialogMockEnv();
+    let busEvents = 0;
+    env.bus.addEventListener("dashboards-shares-updated", () => busEvents++);
+    await mountDialog(env);
+    expect("tbody tr").toHaveCount(2);
+    await contains(".btn-danger").click();
+    expect("tbody tr").toHaveCount(1);
+    expect("tbody tr").toHaveText(/Bob/);
+    expect("tbody tr").toHaveText(/dashboard\/share\/2\/token2/);
+    expect(busEvents).toBe(1);
+});

--- a/spreadsheet_dashboard_oca/tests/__init__.py
+++ b/spreadsheet_dashboard_oca/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_share_management

--- a/spreadsheet_dashboard_oca/tests/test_share_management.py
+++ b/spreadsheet_dashboard_oca/tests/test_share_management.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Volkan Tasci
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import AccessError
+from odoo.tests import HttpCase, new_test_user
+
+from odoo.addons.spreadsheet_dashboard.tests.common import DashboardTestCommon
+
+
+class TestShareManagement(DashboardTestCommon, HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user2 = new_test_user(cls.env, login="Bob")
+        cls.user2.group_ids |= cls.group
+        cls.manager = new_test_user(
+            cls.env,
+            login="Manager",
+            groups="spreadsheet_dashboard.group_dashboard_manager",
+        )
+
+    def _share_as(self, user, dashboard):
+        return (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(user)
+            .create(
+                {
+                    "dashboard_id": dashboard.id,
+                    "spreadsheet_data": dashboard.spreadsheet_data,
+                }
+            )
+        )
+
+    def test_list_only_own_shares(self):
+        dashboard = self.create_dashboard()
+        share_raoul = self._share_as(self.user, dashboard)
+        share_bob = self._share_as(self.user2, dashboard)
+
+        shares = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.user)
+            .action_get_dashboard_shares(dashboard.id)
+        )
+        self.assertEqual(len(shares), 1)
+        self.assertEqual(shares[0]["id"], share_raoul.id)
+        self.assertEqual(shares[0]["full_url"], share_raoul.full_url)
+        self.assertEqual(shares[0]["name"], dashboard.name)
+        self.assertEqual(shares[0]["create_uid"], self.user.display_name)
+        self.assertTrue(shares[0]["create_date"])
+        self.assertNotEqual(shares[0]["id"], share_bob.id)
+
+    def test_manager_sees_all_shares(self):
+        dashboard = self.create_dashboard()
+        share_raoul = self._share_as(self.user, dashboard)
+        share_bob = self._share_as(self.user2, dashboard)
+
+        shares = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.manager)
+            .action_get_dashboard_shares(dashboard.id)
+        )
+        self.assertEqual(
+            {share["id"] for share in shares}, {share_raoul.id, share_bob.id}
+        )
+
+    def test_unshare_own_share(self):
+        dashboard = self.create_dashboard()
+        share = self._share_as(self.user, dashboard)
+
+        result = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.user)
+            .action_unshare([share.id])
+        )
+        self.assertTrue(result)
+        self.assertFalse(
+            self.env["spreadsheet.dashboard.share"].search([("id", "=", share.id)])
+        )
+
+    def test_cannot_unshare_other_users_share(self):
+        dashboard = self.create_dashboard()
+        share = self._share_as(self.user2, dashboard)
+
+        with self.assertRaises(AccessError):
+            (
+                self.env["spreadsheet.dashboard.share"]
+                .with_user(self.user)
+                .action_unshare([share.id])
+            )
+
+    def test_manager_can_unshare_other_users_share(self):
+        dashboard = self.create_dashboard()
+        share = self._share_as(self.user2, dashboard)
+
+        result = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.manager)
+            .action_unshare([share.id])
+        )
+        self.assertTrue(result)
+        self.assertFalse(
+            self.env["spreadsheet.dashboard.share"].search([("id", "=", share.id)])
+        )
+
+    def test_unshared_link_returns_404(self):
+        dashboard = self.create_dashboard()
+        share = self._share_as(self.user, dashboard)
+        access_token = share.access_token
+        share.with_user(self.user).action_unshare([share.id])
+
+        response = self.url_open(f"/dashboard/share/{share.id}/{access_token}")
+        self.assertEqual(response.status_code, 404)
+
+    def test_share_counts_own_shares_only(self):
+        dashboard = self.create_dashboard()
+        self._share_as(self.user, dashboard)
+        self._share_as(self.user2, dashboard)
+
+        counts = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.user)
+            .action_get_share_counts()
+        )
+        self.assertEqual(counts[dashboard.id], 1)
+
+    def test_share_counts_manager_sees_all(self):
+        dashboard = self.create_dashboard()
+        self._share_as(self.user, dashboard)
+        self._share_as(self.user2, dashboard)
+
+        counts = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.manager)
+            .action_get_share_counts()
+        )
+        self.assertEqual(counts[dashboard.id], 2)
+
+    def test_share_counts_empty_for_dashboard_without_shares(self):
+        dashboard = self.create_dashboard()
+
+        counts = (
+            self.env["spreadsheet.dashboard.share"]
+            .with_user(self.manager)
+            .action_get_share_counts()
+        )
+        self.assertNotIn(dashboard.id, counts)


### PR DESCRIPTION
Following maintainer feedback, the share-link management feature previously proposed as the standalone `spreadsheet_dashboard_share_oca` module is now folded directly into the main `spreadsheet_dashboard_oca` module.

Core's `spreadsheet_dashboard` only lets users *create* share links; there is no UI to list or revoke them. This PR adds:

- a "Manage shares" entry on the dashboard Share button, opening a dialog to list, copy and revoke the share links of a dashboard;
- a badge next to the dashboard name in the sidebar showing the number of active shares;
- an `ir.rule` so `spreadsheet_dashboard.group_dashboard_manager` users can manage the shares created by any user (other users manage their own).

Python and JS tests moved along; module version bumped to `19.0.2.0.0`.
